### PR TITLE
Update houdini.env

### DIFF
--- a/houdini.env
+++ b/houdini.env
@@ -14,6 +14,10 @@
 # HOUDINI_OTLSCAN_PATH = $QLIB/otls;$AELIB/otls;$SILIB/otls;& 
 # You should have only a single "&" on the end of each line. 
 
+# External web browser for the help
+HOUDINI_EXTERNAL_HELP_BROWSER = 1
+
+# Load libraries
 HOUDINI_OTLSCAN_PATH = $SILIB/otls;&
 HOUDINI_GALLERY_PATH = $SILIB/gallery;&
 HOUDINI_TOOLBAR_PATH = $SILIB/toolbar;&


### PR DESCRIPTION
Opening an external web browser allows Houdini to spawn it and minimises crashes and compatibility. Easier to navigate and integrate in your bookmarks.